### PR TITLE
Fixed long double

### DIFF
--- a/tortellini.hh
+++ b/tortellini.hh
@@ -196,7 +196,7 @@ public:
 		>::type to_string(T r) const {
 			if (std::is_same<T, bool>::value) {
 				return r ? "yes" : "no";
-			} else if (std::is_same<T, float>::value || std::is_same<T, double>::value) {
+			} else if (std::is_floating_point<T>::value) {
 				std::ostringstream out;
 				out << std::setprecision(std::numeric_limits<T>::max_digits10 - 1) << r;
 				return out.str();


### PR DESCRIPTION
Long double was left out of the comparison so was missing from the conversion and was becoming an integer. https://en.cppreference.com/w/cpp/types/is_floating_point fixes this.

This will cause #14 PR tests to pass.