### PR TITLE
Enable comments in .INI files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required (VERSION 3.5)
 project (tortellini)
-cmake_minimum_required (VERSION 3.2)
 
 add_library (tortellini INTERFACE)
 target_include_directories (tortellini INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/include/tortellini.hh
+++ b/include/tortellini.hh
@@ -336,6 +336,23 @@ private:
 		rtrim(s);
 	}
 
+	static inline void strip_comments(std::string &s) {
+		bool escaped = false;
+		for (size_t i = 0; i < s.size(); ++i) {
+			char c = s[i];
+			if (c == '\\' && !escaped) {
+				escaped = !escaped;
+				s.erase(i,1); // erase the escape character '\'
+				--i;
+			} else if (escaped) {
+				escaped = !escaped;
+			} else if (c == '#') {
+				s.erase(i);
+				return;
+			}
+		}
+	}
+
 public:
 	class iterator {
 		friend class ini;
@@ -402,6 +419,7 @@ public:
 				}
 			}
 
+			strip_comments(line);
 			trim(line);
 
 			if (line.empty()) continue;

--- a/test.cc
+++ b/test.cc
@@ -519,3 +519,27 @@ TEST_CASE("Iterating an INI") {
 		}
 	}
 }
+
+TEST_CASE("Parsing an INI with comments") {
+	tortellini::ini ini;
+
+	SECTION("Can read a value with a comment next to it") {
+		test_read<bool>("true#comment", true);
+		test_read<bool>("true #comment", true);
+		test_read<bool>("false # another comment", false);
+		test_read<bool>("false # one more comment\n# on multiple lines", false);
+	}
+
+	SECTION("Can read values with an escaped # character inside") {
+		test_read<std::string>("user\\#name", "user#name");
+		test_read<std::string>("\\# fake comment # real comment", "# fake comment");
+		test_read<std::string>("\\# fake comment # real comment", "# fake comment");
+		test_read<std::string>("\\#\\#\\####", "###");
+	}
+
+	SECTION("Comment is treated as invalid value") {
+		std::istringstream("v = #hello") >> ini;
+		const auto v = ini[""]["v"] | 42.0;
+		CHECK(v == 42.0);
+	}
+}


### PR DESCRIPTION
In .INI files, comments are often essential in order to show the user what each setting is supposed to do. This tiny pull request should allow Tortellini to process .INI files that contain comments.

Comments begin with a `#` character and end with a newline. In order to allow Strings that contain `#`, I made it so that the widely accepted escape character `\` can be used to override the default behaviour. Some examples:
```python
# The following is a configuration file
v1 = # this is a comment
v2 = \# this is NOT a comment
v3 = \#\#\#
```
Effect of the above .INI file:
- The first line is ignored, as if it was just whitespace.
- Key `v1` is invalid data because the comment is removed before processing, leaving only "v1 = ".
- Key `v2` contains the string "# this is NOT a comment".
- Key `v3` contains the string "###".

This pull request includes some test cases I used to make sure the feature was working as intended. Some more test cases could be necessary.